### PR TITLE
use buildkite agent user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM node:10
 
 RUN groupmod -g 999 node && usermod -u 999 -g 999 node
-RUN usermod -d /home/buildkite-agent -l buildkite-agent node
 
 RUN \
     wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
@@ -16,4 +15,4 @@ RUN \
 CMD \
     Xvfb -ac $DISPLAY &
 
-USER buildkite-agent
+USER node

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM node:10
 
+RUN groupmod -g 999 node && usermod -u 999 -g 999 node
+RUN usermod -d /home/buildkite-agent -l buildkite-agent node
+
 RUN \
     wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
     echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list && \
@@ -12,3 +15,5 @@ RUN \
 
 CMD \
     Xvfb -ac $DISPLAY &
+
+USER buildkite-agent

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM node:10
 
-# chrome
 RUN \
     wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
     echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list && \
@@ -8,7 +7,6 @@ RUN \
     apt-get install -y google-chrome-stable xvfb && \
     rm -rf /var/lib/apt/lists/*
 
-# xvfb
 RUN \
     export DISPLAY=:99.0
 

--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ Docker image which has installed the following:
 - Chrome
 - Xvfb
 
-Also see [Docker Hub](https://hub.docker.com/r/joscha/node-yarn-chrome-xvfb/).
+Also see [Docker Hub](https://hub.docker.com/r/canvadev/node-yarn-chrome-xvfb/).


### PR DESCRIPTION
The standard user in the `node:10` image is `root`. Running `yarn install` with this user results in files created under UID 0, which then, at the next job run, the buildkite-agent can't remove (buildkite-agent is UID 999) as it doesn't have any access. This aligns the UID of the `node` user coming from the `docker-node` image with the UID of the `buildkite-agent` user and also sets the `node` user as the default.